### PR TITLE
Add double click action for legend items

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -187,6 +187,58 @@
         localStorage.setItem(getCacheKey(), null);
     }
 
+    let prevClick;
+    function isDoubleClick() {
+        let now = new Date();
+        if (!prevClick) {
+            prevClick = now;
+            return false;
+        }
+
+        let diff = now - prevClick;
+        prevClick = now;
+
+        return diff < 300;
+    }
+
+    function legendOnClick(e, li) {
+        // always do default click behavior
+        Chart.defaults.global.legend.onClick.apply(this, [e, li]);
+        
+        if (isDoubleClick()) {
+            let chart = this.chart;
+
+            // always show doubleclicked item
+            chart.getDatasetMeta(li.datasetIndex).hidden = false;
+            
+            // count how many hidden datasets are there
+            let hiddenCnt = chart.data.datasets
+                .map(function(_dataSet, dataSetIndex) {
+                    return chart.getDatasetMeta(dataSetIndex);
+                }).filter(function(meta) {
+                    return meta.hidden;
+                }).length;
+
+            // deciding to invert items 'hidden' state depending 
+            // if they are already mostly hidden
+            let hide = true;
+            if (hiddenCnt >= (chart.data.datasets.length - 1) * 0.5) {
+                hide = false;
+            }
+
+            chart.data.datasets.forEach(function(_dataSet, dataSetIndex) {
+                if (dataSetIndex === li.datasetIndex) {
+                    return;
+                }
+
+                let dsMeta = chart.getDatasetMeta(dataSetIndex);
+                dsMeta.hidden = hide;
+            });
+
+            chart.update();
+        }
+    }
+
     function getLeaderboardJson() {
         // 1. Check if dummy data was loaded...
         if (!!aoc.dummyData) {
@@ -388,6 +440,7 @@
                         labels: {
                             fontColor: aocColors["main"],
                         },
+                        onClick: legendOnClick
                     },
                     title: {
                         display: true,
@@ -488,6 +541,7 @@
                         labels: {
                             fontColor: aocColors["main"],
                         },
+                        onClick: legendOnClick
                     },
                     title: {
                         display: true,
@@ -568,6 +622,7 @@
                         labels: {
                             fontColor: aocColors["main"],
                         },
+                        onClick: legendOnClick
                     },
                     title: {
                         display: true,
@@ -655,6 +710,7 @@
                         labels: {
                             fontColor: aocColors["main"],
                         },
+                        onClick: legendOnClick
                     },
                     title: {
                         display: true,

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -209,7 +209,7 @@
             let chart = this.chart;
 
             // always show doubleclicked item
-            chart.getDatasetMeta(li.datasetIndex).hidden = false;
+            chart.getDatasetMeta(li.datasetIndex).hidden = null;
             
             // count how many hidden datasets are there
             let hiddenCnt = chart.data.datasets
@@ -223,7 +223,7 @@
             // if they are already mostly hidden
             let hide = true;
             if (hiddenCnt >= (chart.data.datasets.length - 1) * 0.5) {
-                hide = false;
+                hide = null;
             }
 
             chart.data.datasets.forEach(function(_dataSet, dataSetIndex) {


### PR DESCRIPTION
This is a pain when we have around 50 people in our private leaderboard, but you only want to compare several of them.

How the feature in PR works: 
1) double click on any item will always make the corresponding dataset visible
2) all the other datasets will be either hidden or shown, depending on the state of the majority of them. They will be inverted.
3) in this way it takes one double click to go into "one selected" mode and another double click to go back to "all selected"

Try it out, it feels pretty good.

The implementation is simplistic, of course.