### PR TITLE
Make changes to medal overview

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -446,7 +446,6 @@
                         span.style.borderRadius = "2px";
                         span.style.border = "1px solid #333";
                         span.style.backgroundColor = medalColor(secondPuzzlePodiumPlace);
-                        span.style.opacity = 1.0;
                         
                         let memberStar1 = member.stars.find(s => s.dayNr === d && s.starNr === 1);
                         let memberStar2 = member.stars.find(s => s.dayNr === d && s.starNr === 2);
@@ -457,9 +456,10 @@
 
                         if (secondPuzzlePodiumPlace >= 0 && secondPuzzlePodiumPlace < podiumLength) {
                             medalCount++;
+                            div.style.opacity = 0.5 + (0.5 * ((podiumLength - secondPuzzlePodiumPlace) / podiumLength));
                         } else {
                             span.innerText = secondPuzzlePodiumPlace >= 0 ? secondPuzzlePodiumPlace : '\u2003';
-                            span.style.opacity = 0.2;
+                            span.style.opacity = 0.25;
                         }
                     }
                 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -458,7 +458,7 @@
                             medalCount++;
                             div.style.opacity = 0.5 + (0.5 * ((podiumLength - secondPuzzlePodiumPlace) / podiumLength));
                         } else {
-                            span.innerText = secondPuzzlePodiumPlace >= 0 ? secondPuzzlePodiumPlace : '\u2003';
+                            span.innerText = secondPuzzlePodiumPlace >= 0 ? (secondPuzzlePodiumPlace + 1) : '\u2003';
                             span.style.opacity = 0.25;
                         }
                     }


### PR DESCRIPTION
Some changes to the medal overview.

- this also adds tooltips with star retrieval times
- subtly with dim numbers (look closely!) show what place someone did
  make for puzzle 2
- show with a more prominent "border" what podium place you got for
  puzzle 1
- also show people in the grid that only ever got a 'medal' for puzzle 1
- also show the puzzle 1 "border" even when the person didn't reach
  podium for puzzle 2

Fixes #25