### PR TITLE
Use full member list to get member count

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -77,6 +77,7 @@
         let stars = [];
         let year = parseInt(json.event);
 
+        let n_members = Object.keys(json.members).length;
         let members = Object.keys(json.members)
             .map(k => json.members[k])
             .map(m => {
@@ -128,7 +129,7 @@
         for (let i = 1; i <= 25; i++) {
             availablePoints[i] = {};
             for (let j = 1; j <= 2; j++) {
-                availablePoints[i][j] = members.length;
+                availablePoints[i][j] = n_members;
             }
         }
 


### PR DESCRIPTION
I noticed a small issue where the `leaderboard (points)` graph would have incorrect totals if some users had not submitted any solutions. Looks like it was caused by `members` only containing users who had at least one star since the transformation of `json.members` to `members` dropped all users who don't have a star.