### PR TITLE
Feature: Show table with per-day time and points

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -478,7 +478,6 @@
             gridElement.style.fontSize = "16px";
 
             let grid = data.members;
-            let count = 0;
             grid.sort(function (a, b) {
                 let aPoints = a.stars.filter(s => s.dayNr == displayDay).reduce((acc, v) => acc + v.points, 0);
                 let bPoints = b.stars.filter(s => s.dayNr == displayDay).reduce((acc, v) => acc + v.points, 0);
@@ -490,6 +489,7 @@
                 td.align = "center";
             }
             {
+                // first row header
                 let tr = gridElement.appendChild(document.createElement("tr"));
                 let td = tr.appendChild(document.createElement("td"))
 
@@ -509,6 +509,7 @@
                 td = tr.appendChild(document.createElement("td"));
             }
             {
+                // second row header
                 let tr = gridElement.appendChild(document.createElement("tr"));
                 let td = tr.appendChild(document.createElement("td"));
 
@@ -555,80 +556,80 @@
                 td = tr.appendChild(document.createElement("td"));
             }
 
+            // Fill the actual data
+            let rank = 0;
             for (let member of grid) {
+                rank += 1;
+
                 let memberStar1 = member.stars.find(s => s.dayNr === displayDay && s.starNr === 1);
                 let memberStar2 = member.stars.find(s => s.dayNr === displayDay && s.starNr === 2);
 
-                count += 1;
                 let tr = gridElement.appendChild(document.createElement("tr"));
-                {
-                    let td = tr.appendChild(document.createElement("td"))
-                    td.innerText = count.toString() + ")";
-                    td.style.border = "1px solid #333";
-                    setCellStyle(td);
+                let td = tr.appendChild(document.createElement("td"))
+                td.innerText = rank.toString() + ")";
+                td.style.border = "1px solid #333";
+                setCellStyle(td);
 
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = (memberStar1 ? formatTimeTaken(memberStar1.timeTakenSeconds) : "")
-                    td.title = memberStar1 ?
-                        formatStarMomentForTitle(memberStar1) :
-                        "Star 1 not done yet";
-                    td.style.border = "1px solid #333";
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = (memberStar1 ? formatTimeTaken(memberStar1.timeTakenSeconds) : "")
+                td.title = memberStar1 ?
+                    formatStarMomentForTitle(memberStar1) :
+                    "Star 1 not done yet";
+                td.style.border = "1px solid #333";
 
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = (memberStar1 ? memberStar1.rank : "")
-                    td.style.border = "1px solid #333";
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = (memberStar1 ? memberStar1.rank : "")
+                td.style.border = "1px solid #333";
 
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = (memberStar1 ? memberStar1.points : "")
-                    td.style.border = "1px solid #333";
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = (memberStar1 ? memberStar1.points : "")
+                td.style.border = "1px solid #333";
 
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = (memberStar2 ? formatTimeTaken(memberStar2.timeTakenSeconds) : "");
-                    td.title = memberStar2 ?
-                        formatStarMomentForTitle(memberStar2) :
-                        "Star 2 not done yet";
-                    td.style.border = "1px solid #333";
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = (memberStar2 ? formatTimeTaken(memberStar2.timeTakenSeconds) : "");
+                td.title = memberStar2 ?
+                    formatStarMomentForTitle(memberStar2) :
+                    "Star 2 not done yet";
+                td.style.border = "1px solid #333";
 
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = (memberStar2 ? memberStar2.rank : "")
-                    td.style.border = "1px solid #333";
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = (memberStar2 ? memberStar2.rank : "")
+                td.style.border = "1px solid #333";
 
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = (memberStar2 ? memberStar2.points : "");
-                    td.style.border = "1px solid #333";
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = (memberStar2 ? memberStar2.points : "");
+                td.style.border = "1px solid #333";
 
-                    let totalScore = 0;
-                    if (memberStar1) {
-                        totalScore += memberStar1.points;
-                    }
-                    if (memberStar2) {
-                        totalScore += memberStar2.points;
-                    }
-
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = totalScore ? totalScore : "";
-                    td.style.border = "1px solid #333";
-
-
-                    td = tr.appendChild(document.createElement("td"));
-                    setCellStyle(td);
-                    td.innerText = memberStar2 ?
-                        formatTimeTaken(memberStar2.timeTakenSeconds - memberStar1.timeTakenSeconds) :
-                        "";
-                    td.style.border = "1px solid #333";
-
-                    td = tr.appendChild(document.createElement("td"))
-                    setCellStyle(td);
-                    td.innerText = member.name;
-                    td.style.border = "1px solid #333";
+                let totalScore = 0;
+                if (memberStar1) {
+                    totalScore += memberStar1.points;
                 }
+                if (memberStar2) {
+                    totalScore += memberStar2.points;
+                }
+
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = totalScore ? totalScore : "";
+                td.style.border = "1px solid #333";
+
+                td = tr.appendChild(document.createElement("td"));
+                setCellStyle(td);
+                td.innerText = memberStar2 ?
+                    formatTimeTaken(memberStar2.timeTakenSeconds - memberStar1.timeTakenSeconds) :
+                    "";
+                td.style.border = "1px solid #333";
+
+                td = tr.appendChild(document.createElement("td"))
+                setCellStyle(td);
+                td.innerText = member.name;
+                td.style.border = "1px solid #333";
             }
 
             this.perDayLeaderBoard.appendChild(gridElement);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,4 +1,4 @@
-(function(aoc) {
+(function (aoc) {
     // Based on https://stackoverflow.com/a/38493678/419956 by @user6586783
     Chart.pluginService.register({
         beforeDraw: function (chart, easing) {
@@ -36,7 +36,7 @@
     function colorWithOpacity(color, alpha) {
         if (color.includes("#")) {
             return Chart.helpers.color(color).alpha(alpha).rgbString();
-        } else if (color.includes("hsl")){
+        } else if (color.includes("hsl")) {
             return `${color.slice(0, -1)}, ${alpha})`;
         } else {
             return color;
@@ -56,10 +56,10 @@
 
         if (rainbow)
             // Dynamic rainbow palette using hsl()
-            return [...Array(n).keys()].map(i => "hsl(" + i*300/n + ", 100%, 50%)");
+            return [...Array(n).keys()].map(i => "hsl(" + i * 300 / n + ", 100%, 50%)");
 
         // Dynamic fire palette red->yellow->green using hsl()
-        return [...Array(n).keys()].map(i => "hsl(" + i*120/n + ", 100%, 50%)")
+        return [...Array(n).keys()].map(i => "hsl(" + i * 120 / n + ", 100%, 50%)")
     }
 
     function adjustPoinstFor(year, dayKey, starKey, basePoints) {
@@ -183,11 +183,11 @@
         let colors = getPalette(members.length, isRainbow, isOriginal);
 
         if (orderByScore)
-            members.sort((a, b) => b.score-a.score).forEach((m, idx) => m.color = colors[idx]);
+            members.sort((a, b) => b.score - a.score).forEach((m, idx) => m.color = colors[idx]);
         else
             members.forEach((m, idx) => m.color = colors[idx]);
 
-        return{
+        return {
             maxDay: maxDay,
             maxMoment: maxMoment,
             days: days,
@@ -479,15 +479,15 @@
 
             let grid = data.members;
             let count = 0;
-            grid.sort(function(a, b) {
+            grid.sort(function (a, b) {
                 let aPoints = a.stars.filter(s => s.dayNr == displayDay).reduce((acc, v) => acc + v.points, 0);
                 let bPoints = b.stars.filter(s => s.dayNr == displayDay).reduce((acc, v) => acc + v.points, 0);
                 return bPoints - aPoints;
             });
 
             let setCellStyle = function (td) {
-                td.style.padding = "2px 8px";   
-                td.align = "center"; 
+                td.style.padding = "2px 8px";
+                td.align = "center";
             }
             {
                 let tr = gridElement.appendChild(document.createElement("tr"));
@@ -570,7 +570,7 @@
                     td = tr.appendChild(document.createElement("td"))
                     setCellStyle(td);
                     td.innerText = (memberStar1 ? formatTimeTaken(memberStar1.timeTakenSeconds) : "")
-                    td.title = memberStar1 ? 
+                    td.title = memberStar1 ?
                         formatStarMomentForTitle(memberStar1) :
                         "Star 1 not done yet";
                     td.style.border = "1px solid #333";
@@ -588,7 +588,7 @@
                     td = tr.appendChild(document.createElement("td"))
                     setCellStyle(td);
                     td.innerText = (memberStar2 ? formatTimeTaken(memberStar2.timeTakenSeconds) : "");
-                    td.title = memberStar2 ? 
+                    td.title = memberStar2 ?
                         formatStarMomentForTitle(memberStar2) :
                         "Star 2 not done yet";
                     td.style.border = "1px solid #333";
@@ -619,8 +619,8 @@
 
                     td = tr.appendChild(document.createElement("td"));
                     setCellStyle(td);
-                    td.innerText = memberStar2 ? 
-                        formatTimeTaken(memberStar2.timeTakenSeconds - memberStar1.timeTakenSeconds) : 
+                    td.innerText = memberStar2 ?
+                        formatTimeTaken(memberStar2.timeTakenSeconds - memberStar1.timeTakenSeconds) :
                         "";
                     td.style.border = "1px solid #333";
 
@@ -849,7 +849,7 @@
         loadTimePerStar(data) {
             let datasets = [];
             let n = Math.min(3, data.members.length);
-            let relevantMembers = data.members.sort((a,b) => b.score - a.score).slice(0,n);
+            let relevantMembers = data.members.sort((a, b) => b.score - a.score).slice(0, n);
 
             for (let member of relevantMembers) {
                 let star1DataSet = {
@@ -955,7 +955,7 @@
         }
 
         loadPointsOverTime(data) {
-            let datasets = data.members.sort((a,b) => a.name.localeCompare(b.name)).map(m => {
+            let datasets = data.members.sort((a, b) => a.name.localeCompare(b.name)).map(m => {
                 return {
                     label: m.name,
                     lineTension: 0.2,
@@ -1016,7 +1016,7 @@
                                 displayFormats: { day: "D" },
                             },
                             ticks: {
-                                min: moment([data.year,10,30,5,0,0]),
+                                min: moment([data.year, 10, 30, 5, 0, 0]),
                                 max: data.maxMoment,
                                 fontColor: aocColors["main"],
                             },
@@ -1114,7 +1114,7 @@
                                 displayFormats: { day: "D" },
                             },
                             ticks: {
-                                min: moment([data.year,10,30,5,0,0]),
+                                min: moment([data.year, 10, 30, 5, 0, 0]),
                                 max: data.maxMoment,
                                 fontColor: aocColors["main"],
                             },

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -370,6 +370,7 @@
 
             this.wrapper = document.body.appendChild(document.createElement("div"));
             this.controls = this.wrapper.appendChild(document.createElement("div"));
+            this.per_day = this.wrapper.appendChild(document.createElement("div"));
             this.medals = this.wrapper.appendChild(document.createElement("div"));
             this.graphs = this.wrapper.appendChild(document.createElement("div"));
             this.graphs.style.display = "flex";
@@ -381,6 +382,7 @@
 
             getLeaderboardJson()
                 .then(data => this.loadCacheBustingButton(data))
+                .then(data => this.loadPerDayLeaderBoard(data))
                 .then(data => this.loadMedalOverview(data))
                 .then(data => this.loadPointsOverTime(data))
                 .then(data => this.loadStarsOverTime(data))
@@ -419,6 +421,185 @@
             colorToggleLink.style.border = `1px solid ${aocColors.secondary}`;
             colorToggleLink.style.marginLeft = "8px";
             colorToggleLink.addEventListener("click", () => toggleCurrentGraphColorStyle());
+
+            return data;
+        }
+
+        loadPerDayLeaderBoard(data) {
+            this.per_day.title = "Per Day leaderboard";
+            let titleElement = this.per_day.appendChild(document.createElement("p"));
+            titleElement.innerText = "Points Per Day: ";
+            titleElement.style.fontFamily = "Source Code Pro, monospace";
+            titleElement.style.fontWeight = "normal";
+
+            for (let d = 1; d <= data.maxDay; ++d) {
+                let a = titleElement.appendChild(document.createElement("a"));
+                a.innerText = " " + d.toString();
+                if (d == data.maxDay) {
+                    a.style.color = "#ffffff";
+                    a.style.textShadow = "0 0 5px #ffffff";
+                }
+            }
+
+            let gridElement = document.createElement("table");
+            gridElement.style.borderCollapse = "collapse";
+            gridElement.style.fontSize = "16px";
+
+            let grid = data.members;
+            let count = 0;
+            let starCmp = function(aStar, bStar) {
+                if (!aStar && !bStar) {
+                    return 0;
+                }
+                if (!aStar) {
+                    return 1;
+                }
+                if (!bStar) {
+                    return -1;
+                }
+                return aStar.getStarMoment.utc().diff(bStar.getStarMoment.utc());
+            }
+
+            grid.sort(function(a, b) {
+                let aStar = a.stars.find(s => s.dayNr === data.maxDay && s.starNr === 2);
+                let bStar = b.stars.find(s => s.dayNr === data.maxDay && s.starNr === 2);
+
+                let aStar1 = a.stars.find(s => s.dayNr === data.maxDay && s.starNr === 1);
+                let bStar1 = b.stars.find(s => s.dayNr === data.maxDay && s.starNr === 1);
+                
+                let r2 = starCmp(aStar, bStar);
+                return r2 != 0 ?  r2 : starCmp(aStar1, bStar1);
+            });
+
+            {
+                let tr = gridElement.appendChild(document.createElement("tr"));
+                let td = tr.appendChild(document.createElement("td"))
+
+                td = tr.appendChild(document.createElement("th"));
+                td.innerText = "--- Part 1 ---";
+                td.style.padding = "2px 8px";   
+                td.align = "center"; 
+                td.style.color = "#9999cc";
+                td.colSpan = 2;
+
+                td = tr.appendChild(document.createElement("th"));
+                td.innerText = "--- Part 2 ---";
+                td.style.padding = "2px 8px";
+                td.style.color = "#ffff66";
+                td.align = "center"; 
+                td.colSpan = 2;
+
+                td = tr.appendChild(document.createElement("td"));
+                td = tr.appendChild(document.createElement("td"));
+            }
+            {
+                let tr = gridElement.appendChild(document.createElement("tr"));
+                let td = tr.appendChild(document.createElement("td"));
+
+                td = tr.appendChild(document.createElement("td"));
+                td.innerText = "Time";
+                td.style.padding = "2px 8px";   
+                td.align = "center"; 
+                td.style.color = "#9999cc";
+
+                td = tr.appendChild(document.createElement("td"));
+                td.innerText = "Points";
+                td.style.padding = "2px 8px";   
+                td.align = "center"; 
+                td.style.color = "#9999cc";
+
+                td = tr.appendChild(document.createElement("td"));
+                td.innerText = "Time";
+                td.style.padding = "2px 8px";   
+                td.align = "center"; 
+                td.style.color = "#ffff66";
+
+                td = tr.appendChild(document.createElement("td"));
+                td.innerText = "Points";
+                td.style.padding = "2px 8px";   
+                td.align = "center"; 
+                td.style.color = "#ffff66";
+
+                td = tr.appendChild(document.createElement("td"));
+                td.innerText = "Total";
+                td.style.padding = "2px 8px";   
+                td.align = "center"; 
+
+                td = tr.appendChild(document.createElement("td"));
+            }
+
+
+            for (let member of grid) {
+                let d = data.maxDay;
+                let memberStar1 = member.stars.find(s => s.dayNr === d && s.starNr === 1);
+                let memberStar2 = member.stars.find(s => s.dayNr === d && s.starNr === 2);
+
+                // if (!memberStar1) {
+                //     continue;
+                // }
+
+                count += 1;
+                let tr = gridElement.appendChild(document.createElement("tr"));
+
+                {
+                    let td = tr.appendChild(document.createElement("td"))
+                    td.innerText = count.toString() + ")";
+                    td.style.border = "1px solid #333";
+                    td.style.padding = "2px 8px";    
+
+
+                    // let td = tr.appendChild(document.createElement("td"))
+                    // td.innerText = (memberStar1 ? memberStar1.getStarMoment.format("YYYY-MM-DD") : "")
+                    // td.style.border = "1px solid #333";
+                    // td.style.padding = "2px 8px";    
+
+                    td = tr.appendChild(document.createElement("td"))
+                    td.innerText = (memberStar1 ? memberStar1.getStarMoment.utcOffset("-0500").format("HH:mm:ss") : "")
+                    td.style.border = "1px solid #333";
+                    td.style.padding = "2px 8px";   
+
+                    td = tr.appendChild(document.createElement("td"))
+                    td.innerText = (memberStar1 ? memberStar1.points : "")
+                    td.style.border = "1px solid #333";
+                    td.style.padding = "2px 8px";   
+
+                    // td = tr.appendChild(document.createElement("td"))
+                    // td.innerText = (memberStar2 ? memberStar2.getStarMoment.format("YYYY-MM-DD") : "");
+                    // td.style.border = "1px solid #333";
+                    // td.style.padding = "2px 8px";    
+
+                    td = tr.appendChild(document.createElement("td"))
+                    td.innerText = (memberStar2 ? memberStar2.getStarMoment.utcOffset("-0500").format("HH:mm:ss") : "");
+                    td.style.border = "1px solid #333";
+                    td.style.padding = "2px 8px";    
+
+                    td = tr.appendChild(document.createElement("td"))
+                    td.innerText = (memberStar2 ? memberStar2.points : "");
+                    td.style.border = "1px solid #333";
+                    td.style.padding = "2px 8px";   
+
+                    let totalScore = 0;
+                    if (memberStar1) {
+                        totalScore += memberStar1.points;
+                    }
+                    if (memberStar2) {
+                        totalScore += memberStar2.points;
+                    }
+                    td = tr.appendChild(document.createElement("td"))
+                    td.innerText = totalScore;
+                    td.style.border = "1px solid #333";
+                    td.style.padding = "2px 8px";                       
+                }
+                {
+                    let td = tr.appendChild(document.createElement("td"));
+                    td.innerText = member.name;
+                    // td.innerText = "(user #" + member.id.toString() + ")";
+                    td.style.border = "1px solid #333";
+                    td.style.padding = "2px 8px";    
+                }
+            }
+
+            this.per_day.appendChild(gridElement);
 
             return data;
         }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -559,10 +559,14 @@
             // Fill the actual data
             let rank = 0;
             for (let member of grid) {
-                rank += 1;
-
                 let memberStar1 = member.stars.find(s => s.dayNr === displayDay && s.starNr === 1);
                 let memberStar2 = member.stars.find(s => s.dayNr === displayDay && s.starNr === 2);
+                // skip users that didn't solve any problem today
+                if (!memberStar1 && !memberStar2) {
+                    continue;
+                }
+
+                rank += 1;
 
                 let tr = gridElement.appendChild(document.createElement("tr"));
                 let td = tr.appendChild(document.createElement("td"))


### PR DESCRIPTION
Implements #39

Screenshot on dummy data:

<img width="1045" alt="Screen Shot 2020-12-07 at 4 53 11 PM" src="https://user-images.githubusercontent.com/426145/101423188-5dda0900-38ad-11eb-9b8b-9071658eac8d.png">



A few notes:
 - Adding this graph right after medal overview:

<img width="1175" alt="Screen Shot 2020-12-07 at 4 56 40 PM" src="https://user-images.githubusercontent.com/426145/101423437-ec4e8a80-38ad-11eb-8b3f-da811e0fd2f4.png">


 - Added additional column `Delta Time` as was suggested in the issue above by @kindermoumoute
 - Per Day link is clickable and is persisted in local storage
 - I refactored rendering of local time for start into separate function `formatStarMomentForTitle` to reuse with existing code
 - I ran format on `app.js` so it created a little bit of unrelated changes. They all look fine to me, but I can remove those changes if needed
