### PR TITLE
Points leaderboard based on percentage

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1134,9 +1134,10 @@
         */
         loadPointsOverTime(data) {
             let graphType = getPointsOverTimeType();
-            let maxPointsPerDay = [];
+            const maxDayNr = Math.max(...data.stars.map(s => s.dayNr));
+            let maxPointsPerDay = Array.from({ length: maxDayNr }, () => data.n_members * 2);
             data.stars.forEach(s => maxPointsPerDay[s.dayNr-1] = s.points > 0 ? data.n_members * 2 : 0);
-            let availablePoints = [[...maxPointsPerDay], [...maxPointsPerDay]];
+            let availablePoints = [maxPointsPerDay.map(p => p/2), maxPointsPerDay.map(p => p/2)];
             data.stars.forEach(s => availablePoints[s.starNr-1][s.dayNr-1] = Math.min(availablePoints[s.starNr-1][s.dayNr-1], Math.max(s.points-1, 0)));
             let datasets = data.members.sort((a, b) => a.name.localeCompare(b.name)).reduce((p,m) => {
                 const days = m.stars.reduce(

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -17,6 +17,7 @@
         "main": "rgba(200, 200, 200, 0.9)",
         "secondary": "rgba(150, 150, 150, 0.9)",
         "tertiary": "rgba(100, 100, 100, 0.5)",
+        "link": "#009900"
     };
 
     const graphColorStyles = [
@@ -355,6 +356,15 @@
     function getTimeTableSort() {
         let value = localStorage.getItem("aoc-flag-v1-delta-sort") || "delta";
         return value;
+    }
+
+    function toggleShowPercentage() {
+        localStorage.setItem("aoc-flag-v1-show-percentage", !isShowPercentageToggled());
+        location.reload();
+    }
+
+    function isShowPercentageToggled() {
+        return !!JSON.parse(localStorage.getItem("aoc-flag-v1-show-percentage"));
     }
 
     let prevClick;
@@ -1117,7 +1127,7 @@
         * @param {IData} data
         */
         loadPointsOverTime(data) {
-            let usePercentage = true;
+            let usePercentage = isShowPercentageToggled();
             let maxPointsPerDay = [];
             data.stars.forEach(s => maxPointsPerDay[s.dayNr-1] = s.points > 0 ? data.n_members * 2 : 0);
             let datasets = data.members.sort((a, b) => a.name.localeCompare(b.name)).map(m => {
@@ -1200,11 +1210,23 @@
                     },
                     title: {
                         display: true,
-                        text: "Leaderboard (points)",
+                        text: `Leaderboard (${usePercentage ? "percentage" : "cumulative"} points) - click to change to ${usePercentage ? "cumulative" : "percentage"} points`,
                         fontSize: 24,
                         fontStyle: "normal",
-                        fontColor: aocColors["main"],
+                        fontColor: aocColors.link,
                         lineHeight: 2.0,
+                    },
+                    onClick: function(ev) {
+                        console.log('onClick', ev, this)
+                        var title = this.titleBlock;
+                        if (!title) {
+                          return;
+                        }
+                     
+                        if (ev.offsetX > title.left && ev.offsetX < title.right &&
+                            ev.offsetY > title.top && ev.offsetY < title.bottom) {
+                            toggleShowPercentage();
+                        }
                     },
                     scales: {
                         xAxes: [{


### PR DESCRIPTION
- display day to day points leaderboard as a percentage of theoretical max points
- even if your leaderboard position does not change, you can see if you are making a progress in your path to the competitor
- displays also days without member point change, as the percentage changes anyway
- switchable with old cumulative points leaderboard (it stays as default)
![obrazek](https://user-images.githubusercontent.com/15669010/145727428-399b1df2-1c29-4289-ad1c-112e26df1aca.png)
