### PR TITLE
Minutes Per Star for all players

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -953,15 +953,16 @@
 
         loadTimePerStar(data) {
             let datasets = [];
-            let n = Math.min(3, data.members.length);
+            let n = Math.min((isResponsivenessToggled() ? 5 : data.members.length), data.members.length);
             let relevantMembers = data.members.sort((a, b) => b.score - a.score).slice(0, n);
 
-            for (let member of relevantMembers) {
+            relevantMembers.forEach( (member, idx) => {
                 let star1DataSet = {
                     label: `${member.name} (★)`,
                     stack: `Stack ${member.name}`,
                     backgroundColor: member.color,
                     data: [],
+                    hidden: idx >= 3
                 };
 
                 let star2DataSet = {
@@ -969,6 +970,7 @@
                     stack: `Stack ${member.name}`,
                     backgroundColor: colorWithOpacity(member.color, 0.5),
                     data: [],
+                    hidden: idx >= 3
                 };
 
                 for (let i = 1; i <= 25; i++) {
@@ -991,9 +993,9 @@
 
                 datasets.push(star1DataSet);
                 datasets.push(star2DataSet);
-            }
+            });
 
-            let element = this.createGraphCanvas(data, "From the top players, show the number of minutes taken each day. (Exclude results over 4 hours.)");
+            let element = this.createGraphCanvas(data, "From the top players, show the number of minutes taken each day. (Exclude results over 4 hours.) (Toggle Responsive for all users)");
             this.graphs.appendChild(element);
 
             let chart = new Chart(element.getContext("2d"), {
@@ -1015,7 +1017,7 @@
                     },
                     title: {
                         display: true,
-                        text: `Minutes taken per star - top ${n} players`,
+                        text: `Minutes taken per star`,
                         fontSize: 24,
                         fontStyle: "normal",
                         fontColor: aocColors["main"],


### PR DESCRIPTION
In the Minutes Per Star chart only the top 3 player where shown.

It is not possible to compare your times with any other player.

Now depending of Responsive it shows the top 5 (2 hidden) or all players (n-3 hidden).

There is a problem with the legenda of ChartJS, With many players the legenda goes outside the chart drawing (top-bottom) and then these legenda parts are not clickable (toggle hidden). I will make a test program and an issue at ChartJS repo.
It make a second column of users but also draw a few users in the first column on the wrong spot.