### PR TITLE
use star_index instead of get_star_ts for sorting

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -44,7 +44,7 @@
     }
 
     function starSorter(a, b) {
-        return a.getStarMoment.utc().diff(b.getStarMoment.utc());
+        return a.starIndex - b.starIndex;
     }
 
     function getPalette(n, rainbow, original) {
@@ -101,6 +101,7 @@
                             getStarDay: parseInt(`${dayKey}.${starKey}`, 10),
                             getStarTimestamp: m.completion_day_level[dayKey][starKey].get_star_ts,
                             getStarMoment: starMoment,
+                            starIndex: m.completion_day_level[dayKey][starKey].star_index,
                             timeTaken: null, // adding this later on, which is easier :D
                             timeTakenSeconds: null, // adding this later on as well
                         };

--- a/src/js/dummyData.js
+++ b/src/js/dummyData.js
@@ -7,55 +7,55 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543675444"
+                            "get_star_ts": 1543675444, "star_index": 1543675444
                         },
                         "2": {
-                            "get_star_ts": "1543675853"
+                            "get_star_ts": 1543675853, "star_index": 1543675853
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1544048513"
+                            "get_star_ts": 1544048513, "star_index": 1544048513
                         },
                         "2": {
-                            "get_star_ts": "1544088513"
+                            "get_star_ts": 1544088513, "star_index": 1544088513
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543835226"
+                            "get_star_ts": 1543835226, "star_index": 1543835226
                         },
                         "2": {
-                            "get_star_ts": "1543839592"
+                            "get_star_ts": 1543839592, "star_index": 1543839592
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1544101317"
+                            "get_star_ts": 1544101317, "star_index": 1544101317
                         },
                         "2": {
-                            "get_star_ts": "1544181317"
+                            "get_star_ts": 1544181317, "star_index": 1544181317
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1544001317"
+                            "get_star_ts": 1544001317, "star_index": 1544001317
                         },
                         "2": {
-                            "get_star_ts": "1544005435"
+                            "get_star_ts": 1544005435, "star_index": 1544005435
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544088513"
+                            "get_star_ts": 1544088513, "star_index": 1544088513
                         },
                         "2": {
-                            "get_star_ts": "1544088923"
+                            "get_star_ts": 1544088923, "star_index": 1544088923
                         }
                     },
                     "7": {
                         "1": {
-                            "get_star_ts": "1544190334"
+                            "get_star_ts": 1544190334, "star_index": 1544190334
                         }
                     }
                 },
@@ -80,18 +80,18 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543640672"
+                            "get_star_ts": 1543640672, "star_index": 1543640672
                         },
                         "2": {
-                            "get_star_ts": "1543640962"
+                            "get_star_ts": 1543640962, "star_index": 1543640962
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543727391"
+                            "get_star_ts": 1543727391, "star_index": 1543727391
                         },
                         "2": {
-                            "get_star_ts": "1543727939"
+                            "get_star_ts": 1543727939, "star_index": 1543727939
                         }
                     }
                 },
@@ -105,58 +105,58 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543640661"
+                            "get_star_ts": 1543640661, "star_index": 1543640661
                         },
                         "2": {
-                            "get_star_ts": "1543642266"
+                            "get_star_ts": 1543642266, "star_index": 1543642266
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543727017"
+                            "get_star_ts": 1543727017, "star_index": 1543727017
                         },
                         "2": {
-                            "get_star_ts": "1543727501"
+                            "get_star_ts": 1543727501, "star_index": 1543727501
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543813968"
+                            "get_star_ts": 1543813968, "star_index": 1543813968
                         },
                         "2": {
-                            "get_star_ts": "1543814094"
+                            "get_star_ts": 1543814094, "star_index": 1543814094
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543901590"
+                            "get_star_ts": 1543901590, "star_index": 1543901590
                         },
                         "2": {
-                            "get_star_ts": "1543901693"
+                            "get_star_ts": 1543901693, "star_index": 1543901693
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1543986872"
+                            "get_star_ts": 1543986872, "star_index": 1543986872
                         },
                         "2": {
-                            "get_star_ts": "1543987387"
+                            "get_star_ts": 1543987387, "star_index": 1543987387
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544074188"
+                            "get_star_ts": 1544074188, "star_index": 1544074188
                         },
                         "2": {
-                            "get_star_ts": "1544074602"
+                            "get_star_ts": 1544074602, "star_index": 1544074602
                         }
                     },
                     "7": {
                         "1": {
-                            "get_star_ts": "1544161008"
+                            "get_star_ts": 1544161008, "star_index": 1544161008
                         },
                         "2": {
-                            "get_star_ts": "1544161099"
+                            "get_star_ts": 1544161099, "star_index": 1544161099
                         }
                     }
                 },
@@ -175,55 +175,55 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543659635"
+                            "get_star_ts": 1543659635, "star_index": 1543659635
                         },
                         "2": {
-                            "get_star_ts": "1543660577"
+                            "get_star_ts": 1543660577, "star_index": 1543660577
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543741662"
+                            "get_star_ts": 1543741662, "star_index": 1543741662
                         },
                         "2": {
-                            "get_star_ts": "1543742697"
+                            "get_star_ts": 1543742697, "star_index": 1543742697
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543827875"
+                            "get_star_ts": 1543827875, "star_index": 1543827875
                         },
                         "2": {
-                            "get_star_ts": "1543833911"
+                            "get_star_ts": 1543833911, "star_index": 1543833911
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543914741"
+                            "get_star_ts": 1543914741, "star_index": 1543914741
                         },
                         "2": {
-                            "get_star_ts": "1543918162"
+                            "get_star_ts": 1543918162, "star_index": 1543918162
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1544002117"
+                            "get_star_ts": 1544002117, "star_index": 1544002117
                         },
                         "2": {
-                            "get_star_ts": "1544002431"
+                            "get_star_ts": 1544002431, "star_index": 1544002431
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544098071"
+                            "get_star_ts": 1544098071, "star_index": 1544098071
                         },
                         "2": {
-                            "get_star_ts": "1544098798"
+                            "get_star_ts": 1544098798, "star_index": 1544098798
                         }
                     },
                     "7": {
                         "1": {
-                            "get_star_ts": "1544191498"
+                            "get_star_ts": 1544191498, "star_index": 1544191498
                         }
                     }
                 },
@@ -238,58 +238,58 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543640433"
+                            "get_star_ts": 1543640433, "star_index": 1543640433
                         },
                         "2": {
-                            "get_star_ts": "1543640570"
+                            "get_star_ts": 1543640570, "star_index": 1543640570
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543726958"
+                            "get_star_ts": 1543726958, "star_index": 1543726958
                         },
                         "2": {
-                            "get_star_ts": "1543727111"
+                            "get_star_ts": 1543727111, "star_index": 1543727111
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543813702"
+                            "get_star_ts": 1543813702, "star_index": 1543813702
                         },
                         "2": {
-                            "get_star_ts": "1543814067"
+                            "get_star_ts": 1543814067, "star_index": 1543814067
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543900950"
+                            "get_star_ts": 1543900950, "star_index": 1543900950
                         },
                         "2": {
-                            "get_star_ts": "1543901477"
+                            "get_star_ts": 1543901477, "star_index": 1543901477
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1543986501"
+                            "get_star_ts": 1543986501, "star_index": 1543986501
                         },
                         "2": {
-                            "get_star_ts": "1543986773"
+                            "get_star_ts": 1543986773, "star_index": 1543986773
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544078401"
+                            "get_star_ts": 1544078401, "star_index": 1544078401
                         },
                         "2": {
-                            "get_star_ts": "1544086872"
+                            "get_star_ts": 1544086872, "star_index": 1544086872
                         }
                     },
                     "7": {
                         "1": {
-                            "get_star_ts": "1544160058"
+                            "get_star_ts": 1544160058, "star_index": 1544160058
                         },
                         "2": {
-                            "get_star_ts": "1544164899"
+                            "get_star_ts": 1544164899, "star_index": 1544164899
                         }
                     }
                 },
@@ -301,26 +301,26 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543640910"
+                            "get_star_ts": 1543640910, "star_index": 1543640910
                         },
                         "2": {
-                            "get_star_ts": "1543642654"
+                            "get_star_ts": 1543642654, "star_index": 1543642654
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543727866"
+                            "get_star_ts": 1543727866, "star_index": 1543727866
                         },
                         "2": {
-                            "get_star_ts": "1543728460"
+                            "get_star_ts": 1543728460, "star_index": 1543728460
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543817038"
+                            "get_star_ts": 1543817038, "star_index": 1543817038
                         },
                         "2": {
-                            "get_star_ts": "1543817884"
+                            "get_star_ts": 1543817884, "star_index": 1543817884
                         }
                     }
                 },
@@ -339,58 +339,58 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543640753"
+                            "get_star_ts": 1543640753, "star_index": 1543640753
                         },
                         "2": {
-                            "get_star_ts": "1543641238"
+                            "get_star_ts": 1543641238, "star_index": 1543641238
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543728583"
+                            "get_star_ts": 1543728583, "star_index": 1543728583
                         },
                         "2": {
-                            "get_star_ts": "1543728929"
+                            "get_star_ts": 1543728929, "star_index": 1543728929
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543814603"
+                            "get_star_ts": 1543814603, "star_index": 1543814603
                         },
                         "2": {
-                            "get_star_ts": "1543814908"
+                            "get_star_ts": 1543814908, "star_index": 1543814908
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543902019"
+                            "get_star_ts": 1543902019, "star_index": 1543902019
                         },
                         "2": {
-                            "get_star_ts": "1543902182"
+                            "get_star_ts": 1543902182, "star_index": 1543902182
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1543988033"
+                            "get_star_ts": 1543988033, "star_index": 1543988033
                         },
                         "2": {
-                            "get_star_ts": "1543988862"
+                            "get_star_ts": 1543988862, "star_index": 1543988862
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544080254"
+                            "get_star_ts": 1544080254, "star_index": 1544080254
                         },
                         "2": {
-                            "get_star_ts": "1544081946"
+                            "get_star_ts": 1544081946, "star_index": 1544081946
                         }
                     },
                     "7": {
                         "1": {
-                            "get_star_ts": "1544160010"
+                            "get_star_ts": 1544160010, "star_index": 1544160010
                         },
                         "2": {
-                            "get_star_ts": "1544165499"
+                            "get_star_ts": 1544165499, "star_index": 1544165499
                         }
                     }
                 },
@@ -400,50 +400,50 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543677435"
+                            "get_star_ts": 1543677435, "star_index": 1543677435
                         },
                         "2": {
-                            "get_star_ts": "1543678080"
+                            "get_star_ts": 1543678080, "star_index": 1543678080
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543733508"
+                            "get_star_ts": 1543733508, "star_index": 1543733508
                         },
                         "2": {
-                            "get_star_ts": "1543763332"
+                            "get_star_ts": 1543763332, "star_index": 1543763332
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543813611"
+                            "get_star_ts": 1543813611, "star_index": 1543813611
                         },
                         "2": {
-                            "get_star_ts": "1543813890"
+                            "get_star_ts": 1543813890, "star_index": 1543813890
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543901390"
+                            "get_star_ts": 1543901390, "star_index": 1543901390
                         },
                         "2": {
-                            "get_star_ts": "1543901623"
+                            "get_star_ts": 1543901623, "star_index": 1543901623
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1543986743"
+                            "get_star_ts": 1543986743, "star_index": 1543986743
                         },
                         "2": {
-                            "get_star_ts": "1543987118"
+                            "get_star_ts": 1543987118, "star_index": 1543987118
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544117396"
+                            "get_star_ts": 1544117396, "star_index": 1544117396
                         },
                         "2": {
-                            "get_star_ts": "1544117777"
+                            "get_star_ts": 1544117777, "star_index": 1544117777
                         }
                     }
                 },
@@ -458,10 +458,10 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543689654"
+                            "get_star_ts": 1543689654, "star_index": 1543689654
                         },
                         "2": {
-                            "get_star_ts": "1543711600"
+                            "get_star_ts": 1543711600, "star_index": 1543711600
                         }
                     }
                 },
@@ -482,28 +482,28 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543640423"
+                            "get_star_ts": 1543640423, "star_index": 1543640423
                         },
                         "2": {
-                            "get_star_ts": "1543640520"
+                            "get_star_ts": 1543640520, "star_index": 1543640520
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543777877"
+                            "get_star_ts": 1543777877, "star_index": 1543777877
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543960344"
+                            "get_star_ts": 1543960344, "star_index": 1543960344
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1544125736"
+                            "get_star_ts": 1544125736, "star_index": 1544125736
                         },
                         "2": {
-                            "get_star_ts": "1544125836"
+                            "get_star_ts": 1544125836, "star_index": 1544125836
                         }
                     }
                 }
@@ -512,58 +512,58 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543640479"
+                            "get_star_ts": 1543640479, "star_index": 1543640479
                         },
                         "2": {
-                            "get_star_ts": "1543640680"
+                            "get_star_ts": 1543640680, "star_index": 1543640680
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543732801"
+                            "get_star_ts": 1543732801, "star_index": 1543732801
                         },
                         "2": {
-                            "get_star_ts": "1543732884"
+                            "get_star_ts": 1543732884, "star_index": 1543732884
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543813463"
+                            "get_star_ts": 1543813463, "star_index": 1543813463
                         },
                         "2": {
-                            "get_star_ts": "1544013693"
+                            "get_star_ts": 1544013693, "star_index": 1544013693
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543902386"
+                            "get_star_ts": 1543902386, "star_index": 1543902386
                         },
                         "2": {
-                            "get_star_ts": "1543902424"
+                            "get_star_ts": 1543902424, "star_index": 1543902424
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1543986567"
+                            "get_star_ts": 1543986567, "star_index": 1543986567
                         },
                         "2": {
-                            "get_star_ts": "1543986871"
+                            "get_star_ts": 1543986871, "star_index": 1543986871
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544073487"
+                            "get_star_ts": 1544073487, "star_index": 1544073487
                         },
                         "2": {
-                            "get_star_ts": "1544073782"
+                            "get_star_ts": 1544073782, "star_index": 1544073782
                         }
                     },
                     "7": {
                         "1": {
-                            "get_star_ts": "1544160180"
+                            "get_star_ts": 1544160180, "star_index": 1544160180
                         },
                         "2": {
-                            "get_star_ts": "1544161319"
+                            "get_star_ts": 1544161319, "star_index": 1544161319
                         }
                     }
                 },
@@ -581,58 +581,58 @@
                 "completion_day_level": {
                     "1": {
                         "1": {
-                            "get_star_ts": "1543690540"
+                            "get_star_ts": 1543690540, "star_index": 1543690540
                         },
                         "2": {
-                            "get_star_ts": "1543691201"
+                            "get_star_ts": 1543691201, "star_index": 1543691201
                         }
                     },
                     "2": {
                         "1": {
-                            "get_star_ts": "1543735545"
+                            "get_star_ts": 1543735545, "star_index": 1543735545
                         },
                         "2": {
-                            "get_star_ts": "1543736319"
+                            "get_star_ts": 1543736319, "star_index": 1543736319
                         }
                     },
                     "3": {
                         "1": {
-                            "get_star_ts": "1543814258"
+                            "get_star_ts": 1543814258, "star_index": 1543814258
                         },
                         "2": {
-                            "get_star_ts": "1543815185"
+                            "get_star_ts": 1543815185, "star_index": 1543815185
                         }
                     },
                     "4": {
                         "1": {
-                            "get_star_ts": "1543903754"
+                            "get_star_ts": 1543903754, "star_index": 1543903754
                         },
                         "2": {
-                            "get_star_ts": "1543904161"
+                            "get_star_ts": 1543904161, "star_index": 1543904161
                         }
                     },
                     "5": {
                         "1": {
-                            "get_star_ts": "1543987099"
+                            "get_star_ts": 1543987099, "star_index": 1543987099
                         },
                         "2": {
-                            "get_star_ts": "1543988426"
+                            "get_star_ts": 1543988426, "star_index": 1543988426
                         }
                     },
                     "6": {
                         "1": {
-                            "get_star_ts": "1544077609"
+                            "get_star_ts": 1544077609, "star_index": 1544077609
                         },
                         "2": {
-                            "get_star_ts": "1544078081"
+                            "get_star_ts": 1544078081, "star_index": 1544078081
                         }
                     },
                     "7": {
                         "1": {
-                            "get_star_ts": "1544168700"
+                            "get_star_ts": 1544168700, "star_index": 1544168700
                         },
                         "2": {
-                            "get_star_ts": "1544170406"
+                            "get_star_ts": 1544170406, "star_index": 1544170406
                         }
                     }
                 },


### PR DESCRIPTION
I've met two players with same timestamp (actually it was for the very first star and two fastest players :)) on private leaderboard. **The charts code sorting got different result that the AoC site.** I've discovered that there is a second property, `star_index`. This propery point to order in which the stars have been aquired (the ones with same timestamp had idx 0 and 18). The idx seems to be normalized, so the first star of first day aquired by fastest player of the private leaderboard have index 0. Following days does not reset the index, it only ascends.

In the dummy data, I've simulated the star_index by reusing timestamp.

The real data:
![obrazek](https://user-images.githubusercontent.com/15669010/209569548-492f909e-138e-4891-8094-8c830ad37b72.png)
![obrazek](https://user-images.githubusercontent.com/15669010/209569581-1169be91-1502-4d5d-be07-118ac9400079.png)
