### PR TITLE
Fixes #95 (gold medals counter broken)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -291,8 +291,8 @@
                             nrOfPointsAfterThisOne: 0,
                             points: 0,
                             rank: 0,
-                            awardedPodiumPlace: 0,
-                            awardedPodiumPlaceFirstPuzzle: 0,
+                            awardedPodiumPlace: -1,
+                            awardedPodiumPlaceFirstPuzzle: -1,
                         };
 
                         stars.push(star);


### PR DESCRIPTION
As I had already seen this bug and diogotcorreia #95 reported it, gold medals counter is broken and count also all the days were people have finished the problem. 

The issue was that podium is ranked 0 for gold, 1 for silver, 2 for bronze but both variables `awardedPodiumPlace` and `awardedPodiumPlaceFirstPuzzle` were initialized to 0... This is why gold was the sum of real gold medals and stars acquired. I fixed it by initializing the variables to -1. **I did not tested it** as I am confident this will work (and was not sure how to test it locally), so you can always try but is should work.