### PR TITLE
FF XrayWrapper fix

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -634,6 +634,7 @@
                 return fetch(url, { credentials: "same-origin" })
                     .then(data => data.json())
                     .then(json => updateCache(json))
+                    .then(() => getCache().data)    // FF refuses to modify the object we fetched (XrayWrapper), so we will create our own copy
                     .then(json => transformRawAocJson(json));
             } else {
                 console.info("Could not find anchor to JSON feed, assuming no charts can be plotted here.");


### PR DESCRIPTION
Should fix the #105 

Every time the data are fetched instead of retrieved from cache, FF complains that we are modifying object we are not entitled to.

> Error: Not allowed to define cross-origin object as property on [Object] or [Array] XrayWrapper

Quick solution is to do what works in other branch - just get the data from cache, even as we just stored it there. Effectively cloning it.