### PR TITLE
Fix sorting key for Total table header

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1157,7 +1157,7 @@
                     th.colSpan = 1;
                     th = tr.appendChild(createHeaderCell("part2", "----- Part 2 -----", "#ffff66"));
                     th.colSpan = 3;
-                    th = tr.appendChild(createHeaderCell("total", "----- Total -----"));
+                    th = tr.appendChild(createHeaderCell("completion", "----- Total -----"));
                     th.colSpan = 1;
                 }
                 {


### PR DESCRIPTION
When clicking the `--- Total ---` header in the Delta-focused stats table, the table doesn't sort by the completion time.
<img width="482" alt="image" src="https://github.com/user-attachments/assets/235f7691-1fef-43d4-88c1-8cfa647f4c76">

This is because the sorting key provided when creating the Total header has a different sorting key than the Points header does. Changing the key from `"total"` to `"completion"` to match the sorting key of the Points header fixes the sorting.