### PR TITLE
feat: use 12 as total number of days for 2025

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -359,6 +359,9 @@
         let orderedStars = stars.sort(starSorter);
 
         for (let star of orderedStars) {
+            if (star.dayNr > daysOfPuzzles) {
+                continue;
+            }
             const basePoints = availablePoints[star.dayKey][star.starKey]--;
             star.points = adjustPoinstFor(year, star.dayKey, star.starKey, basePoints);
             star.rank = n_members - basePoints + 1;
@@ -374,7 +377,10 @@
         }
 
         /** @type {number} */
-        let maxDay = Math.max.apply(Math, stars.filter(s => s.starNr === 2).map(s => s.dayNr))
+        let maxDay = Math.min(
+          Math.max.apply(Math, stars.filter(s => s.starNr === 2).map(s => s.dayNr)),
+          daysOfPuzzles
+        );
         
         /** @type {IDaysMap} */
         let days = {};


### PR DESCRIPTION
This PR closes #111, using only 12 days for Advent of Code 2025.
I replaced the hardcoded `25` day references with a variable set to `12` when year from the parsed data is 2025 (and `25` otherwise).
I verified manually the correct column count for both 2025 and and a couple of the previous years.